### PR TITLE
Rename geocoder to Nominatim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ tests/%.db: tests/innout.geojson tests/innout.csv
 test: tests/test.db
 	geocode-sqlite test tests/test.db innout_test -p tests/test.db -l "{id}" -d .1
 
-.PHONY: nominatum
-nominatum: tests/nominatum.db
-	geocode-sqlite nominatum $^ innout_test \
+.PHONY: nominatim
+nominatim: tests/nominatim.db
+	geocode-sqlite nominatim $^ innout_test \
 		--location "{full}, {city}, {state} {postcode}" \
 		--delay 1 \
 		--user-agent "geocode-sqlite"

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ First, create a SQLite database and insert rows from that spreadsheet using `sql
 sqlite-utils insert data.db data data.csv --csv
 ```
 
-Now, geocode it using OpenStreetMap's Nominatum geocoder.
+Now, geocode it using OpenStreetMap's Nominatim geocoder.
 
 ```sh
-geocode-sqlite nominatum data.db data \
+geocode-sqlite nominatim data.db data \
  --location="{address}, {city}, {state} {zip}" \
  --delay=1 \
  --user-agent="this-is-me"
 ```
 
-In the command above, you're using Nominatum, which is free and only asks for a unique user agent (`--user-agent`).
+In the command above, you're using Nominatim, which is free and only asks for a unique user agent (`--user-agent`).
 
 This will connect to a database (`data.db`) and read all rows from the table `data` (skipping any that already
 have both a `latitude` and `longitude` column filled).
@@ -57,7 +57,7 @@ The CLI currently supports these geocoders:
 - `bing`
 - `googlev3`
 - `mapquest` (and `open-mapquest`)
-- `nominatum`
+- `nominatim`
 
 More will be added soon.
 
@@ -85,10 +85,10 @@ As with the CLI, this assumes you already have a SQLite database and a table of 
 
 ```python
 from geocode_sqlite import geocode_table
-from geopy.geocoders import Nominatum
+from geopy.geocoders import Nominatim
 
 # create a geocoder instance, with some extra options
-nominatum = Nominatum(user_agent="this-is-me", domain="nominatum.local.dev", scheme="http")
+nominatim = Nominatim(user_agent="this-is-me", domain="nominatim.local.dev", scheme="http")
 
 # assuming our database is in the same directory
 count = geocode_table("data.db", "data", query_template="{address}, {city}, {state} {zip}")

--- a/geocode_sqlite/cli.py
+++ b/geocode_sqlite/cli.py
@@ -260,11 +260,11 @@ def mapquest(ctx, database, table, location, delay, latitude, longitude, api_key
     show_default=True,
 )
 @common_options
-def nominatum(
+def nominatim(
     ctx, database, table, location, delay, latitude, longitude, user_agent, domain
 ):
-    "Nominatum (OSM)"
-    click.echo(f"Using Nominatum geocoder at {domain}")
+    "Nominatim (OSM)"
+    click.echo(f"Using Nominatim geocoder at {domain}")
     fill_context(ctx, database, table, location, delay, latitude, longitude)
     return geocoders.Nominatim(user_agent=user_agent, domain=domain)
 


### PR DESCRIPTION
It looks like there is a small typo in the [Nominatim](https://nominatim.org/) geocoder.