### PR TITLE
Require click >= 7.0 to hide commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 VERSION = "0.5.0"
 
-requirements = ["click", "sqlite_utils", "geopy"]
+requirements = ["click>=7.0", "sqlite_utils", "geopy"]
 
 
 def get_long_description():


### PR DESCRIPTION
`@cli.command("test", hidden=True)` needs at least version 7.0 to be supported.