### PR TITLE
GeoJSON and SpatiaLite support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 
 .env
 .vscode
+Pipfile

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ tests/%.db: tests/innout.geojson tests/innout.csv
 
 .PHONY: test
 test: tests/test.db
-	geocode-sqlite test tests/test.db innout_test -p tests/test.db -l "{id}" -d .1
+	geocode-sqlite test tests/test.db innout_test -p tests/test.db -l "{id}" -d .1 --spatialite
 
 .PHONY: nominatim
 nominatim: tests/nominatim.db
@@ -45,8 +45,8 @@ mapbox: tests/mapbox.db
 
 .PHONY: run
 run:
-	datasette serve tests/*.db
+	datasette serve tests/*.db --load-extension spatialite
 
 .PHONY: clean
 clean:
-	rm tests/test.db
+	rm -f tests/test.db

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ From there, we have a set of options passed to every geocoder:
 - delay: a delay between each call (some services require this)
 - latitude: latitude column name
 - longitude: longitude column name
+- geojson: store results as GeoJSON, instead of in latitude and longitude columns
 
 Each geocoder takes additional, specific arguments beyond these, such as API keys. Again, [geopy's documentation](https://geopy.readthedocs.io/en/latest/#module-geopy.geocoders) is an excellent resource.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ Each geocoder needs to know where to find the data it's working with. These are 
 
 From there, we have a set of options passed to every geocoder:
 
-- location: a [string format](https://docs.python.org/3/library/stdtypes.html#str.format) that will be expanded with each row to build a full query, to be geocoded
-- delay: a delay between each call (some services require this)
-- latitude: latitude column name
-- longitude: longitude column name
-- geojson: store results as GeoJSON, instead of in latitude and longitude columns
+- `location`: a [string format](https://docs.python.org/3/library/stdtypes.html#str.format) that will be expanded with each row to build a full query, to be geocoded
+- `delay`: a delay between each call (some services require this)
+- `latitude`: latitude column name
+- `longitude`: longitude column name
+- `geojson`: store results as GeoJSON, instead of in latitude and longitude columns
+- `spatialite`: store results in a SpatiaLite geometry column, instead of in latitude and longitude columns
 
 Each geocoder takes additional, specific arguments beyond these, such as API keys. Again, [geopy's documentation](https://geopy.readthedocs.io/en/latest/#module-geopy.geocoders) is an excellent resource.
 

--- a/geocode_sqlite/cli.py
+++ b/geocode_sqlite/cli.py
@@ -65,7 +65,8 @@ Using this will add a geometry column instead of latitude and longitude columns.
                 "--spatialite",
                 is_flag=True,
                 default=False,
-                help="Store results as a SpatiaLite geometry",
+                help="""Store results as a SpatiaLite geometry.
+Using this will add a geometry column instead of latitude and longitude columns.""",
             ),
             click.pass_context,
         ]


### PR DESCRIPTION
Closes #22 
Closes #24 
Closes #26 

Passing a `--geojson` flag will store results as a GeoJSON geometry, instead of in latitude and longitude columns. 

Using `--spatialite` will add a geometry column and store results as a SpatiaLite binary.

This should make it easier to work with [datasette-geojson](https://github.com/eyeseast/datasette-geojson) and [datasette-geojson-map](https://github.com/eyeseast/datasette-geojson-map).