### PR TITLE
if no bbox options are passed, `value` is None

### DIFF
--- a/geocode_sqlite/cli.py
+++ b/geocode_sqlite/cli.py
@@ -129,7 +129,7 @@ def bbox_option(f):
 
 
 def validate_bbox(ctx, param, value):
-    if len(value) < 4:
+    if value is None or len(value) < 4:
         return None
     return format_bbox(*value)
 


### PR DESCRIPTION
and you can't call `len` on `None`.

just a small bug I found when using the `googlev3` geocoder