### PR TITLE
fix failing tests that exepect an envvar

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+env =
+  D:MAPBOX_API_KEY=foo
+  

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         geocode-sqlite=geocode_sqlite.cli:cli
     """,
     install_requires=requirements,
-    extras_require={"test": ["pytest", "geojson-to-sqlite"]},
+    extras_require={"test": ["pytest", "geojson-to-sqlite", "pytest-env"]},
     tests_require=["geocode-sqlite[test]"],
 )


### PR DESCRIPTION
if `MAPBOX_API_KEY` is not set in the environment, `test_pass_kwargs` fails.

noticed this when trying to run tests locally. the `D` prefix defers to values already set in the environment.

you may not want to introduce a new dependency to your project (namely `pytest-env`), and I would understand that, but just thought I'd bring this to your attention with a suggested fix. take it or leave it! this is a very useful library. thanks!