### PR TITLE
Add OpenCage option to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ mapbox: tests/mapbox.db
 		--delay 1 \
 		--api-key "$(MAPBOX_API_KEY)"
 
+.PHONY: opencage
+opencage: tests/opencage.db
+	geocode-sqlite opencage $^ innout_test \
+		--location "{full}, {city}, {state} {postcode}" \
+		--api-key "$(OPENCAGE_API_KEY)"
 
 .PHONY: run
 run:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The CLI currently supports these geocoders:
 - `mapquest` (and `open-mapquest`)
 - `nominatim`
 - `mapbox`
+- `opencage`
 
 More will be added soon.
 

--- a/geocode_sqlite/cli.py
+++ b/geocode_sqlite/cli.py
@@ -494,3 +494,41 @@ def mapbox(
         proximity=proximity,
     )
     return geocoders.MapBox(api_key=api_key)
+
+
+@cli.command("opencage")
+@click.option(
+    "-k",
+    "--api-key",
+    type=click.STRING,
+    required=True,
+    envvar="OPENCAGE_API_KEY",
+    help="OpenCage geocoding API key",
+)
+@common_options
+def opencage(
+    ctx,
+    database,
+    table,
+    location,
+    delay,
+    latitude,
+    longitude,
+    geojson,
+    spatialite,
+    api_key,
+):
+    "OpenCage"
+    click.echo("Using OpenCage geocoder")
+    fill_context(
+        ctx,
+        database,
+        table,
+        location,
+        delay,
+        latitude,
+        longitude,
+        geojson,
+        spatialite,
+    )
+    return geocoders.OpenCage(api_key=api_key)


### PR DESCRIPTION
I'm a contractor for [OpenCage](https://opencagedata.com/) geocoder. We'd like to add an `opencage` option to the CLI. OpenCage is already available in geopy so I have just copied the existing geocoder code with the relevant options. 

- Added OpenCage as an option to CLI
- Added OpenCage to README
- Added OpenCage test to Makefile